### PR TITLE
ucode: improve handling of reply messages

### DIFF
--- a/ucentral.h
+++ b/ucentral.h
@@ -42,6 +42,6 @@ extern int ucode_ubus(int function, void (*cb)(char *, void*),
 extern void ubus_init(void);
 extern void ubus_deinit(void);
 
-void ws_client_send(char *serial, char *msg);
+void ws_client_send(const char *serial, char *msg, size_t len);
 
 #endif

--- a/websocket.c
+++ b/websocket.c
@@ -36,21 +36,14 @@ ws_send(char *_msg, void *priv)
 }
 
 void
-ws_client_send(char *serial, char *_msg)
+ws_client_send(const char *serial, char *buf, size_t len)
 {
 	struct uc_client *client = avl_find_element(&clients, serial, client, avl);;
-	int len;
-	char *msg;
 
 	if (!client)
 		return;
 
-	len = strlen(_msg) + 1;
-	msg = malloc(len + LWS_PRE);
-
-	strcpy(&msg[LWS_PRE], _msg);
-	lws_write(client->wsi, &msg[LWS_PRE], len, LWS_WRITE_TEXT);
-	free(msg);
+	lws_write(client->wsi, buf, len, LWS_WRITE_TEXT);
 }
 
 static int


### PR DESCRIPTION
 - Prevent leaking memory by avoiding to copy the serial string value
   into a new string copy

 - Serialize message object into dynamic print buffer

 - Reserve LWS headroom in the print buffer directly to avoid additional
   memory copy operations

Signed-off-by: Jo-Philipp Wich <jo@mein.io>